### PR TITLE
Changes in firely-sdk-wip tests because of implementing task 577

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -2989,11 +2989,13 @@
         "output": []
       },
       "firely-sdk-wip": {
-        "errorCount": 0,
+        "errorCount": 2,
         "warningCount": 3,
         "output": [
           "[WARNING] Detected a circular reference for reference urn:uuid:7221aa91-d9e1-44fa-8b90-c5a8c7caeade (at Bundle.entry[7].resource[0].contained[0].managingOrganization[0])",
           "[WARNING] Terminology service failed while validating code 'text/xml' (system ''): Cannot resolve canonical reference 'urn:ietf:bcp:13' to CodeSystem (at Bundle.entry[7].resource[0].contained[0].payloadMimeType[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Bundle.entry[2].resource[0].managingOrganization[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Bundle.entry[5].resource[0].payor[0])",
           "[WARNING] Detected a circular reference for reference #direct (at Bundle.entry[7].resource[0].endpoint[0])"
         ]
       }
@@ -3009,12 +3011,13 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 1,
+        "errorCount": 2,
         "warningCount": 3,
         "output": [
           "[ERROR] Instance failed constraint bdl-5 \"must be a resource unless there's a request or response\" (at Bundle.entry[5])",
           "[WARNING] Detected a circular reference for reference urn:uuid:7221aa91-d9e1-44fa-8b90-c5a8c7caeade (at Bundle.entry[7].resource[0].contained[0].managingOrganization[0])",
           "[WARNING] Terminology service failed while validating code 'text/xml' (system ''): Cannot resolve canonical reference 'urn:ietf:bcp:13' to CodeSystem (at Bundle.entry[7].resource[0].contained[0].payloadMimeType[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Bundle.entry[2].resource[0].managingOrganization[0])",
           "[WARNING] Detected a circular reference for reference #direct (at Bundle.entry[7].resource[0].endpoint[0])"
         ]
       }
@@ -3347,10 +3350,12 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 1,
+        "errorCount": 3,
         "warningCount": 0,
         "output": [
-          "[ERROR] Unable to resolve reference to profile 'http://hl7.org/fhir/1.0/StructureDefinition/extension-Patient.animal'. (at Patient.extension[0])"
+          "[ERROR] Unable to resolve reference to profile 'http://hl7.org/fhir/1.0/StructureDefinition/extension-Patient.animal'. (at Patient.extension[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.identifier[0].assigner[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.managingOrganization[0])"
         ]
       }
     },
@@ -3377,10 +3382,12 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 1,
+        "errorCount": 3,
         "warningCount": 0,
         "output": [
-          "[ERROR] Unable to resolve reference to profile 'http://hl7.org/fhir/1.0/StructureDefinition/extension-Patient.animal'. (at Patient.extension[0])"
+          "[ERROR] Unable to resolve reference to profile 'http://hl7.org/fhir/1.0/StructureDefinition/extension-Patient.animal'. (at Patient.extension[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.identifier[0].assigner[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.managingOrganization[0])"
         ]
       }
     },
@@ -3444,9 +3451,10 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 1,
+        "errorCount": 2,
         "warningCount": 0,
         "output": [
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.extension[0].extension[0].valueReference[0])",
           "[ERROR] Instance count is 0, which is not within the specified cardinality of 1..1 (at Patient.extension[0].extension)"
         ]
       }
@@ -5117,8 +5125,9 @@
       },
       "firely-sdk-wip": {
         "errorCount": 1,
-        "warningCount": 0,
+        "warningCount": 1,
         "output": [
+          "[WARNING] Instance failed constraint sdf-0 \"Name should be usable as an identifier for the module by machine processing applications such as code generation\" (at StructureDefinition)",
           "[ERROR] Instance count is 0, which is not within the specified cardinality of 1..1 (at StructureDefinition.name)"
         ]
       }
@@ -5352,8 +5361,9 @@
       },
       "firely-sdk-wip": {
         "errorCount": 0,
-        "warningCount": 3,
+        "warningCount": 4,
         "output": [
+          "[WARNING] Instance failed constraint cpb-0 \"Name should be usable as an identifier for the module by machine processing applications such as code generation\" (at CapabilityStatement)",
           "[WARNING] Terminology service failed while validating code 'xml' (system ''): Cannot resolve canonical reference 'urn:ietf:bcp:13' to CodeSystem (at CapabilityStatement.format[0])",
           "[WARNING] Terminology service failed while validating code 'json' (system ''): Cannot resolve canonical reference 'urn:ietf:bcp:13' to CodeSystem (at CapabilityStatement.format[1])",
           "[WARNING] Terminology service failed while validating code 'application/fhir+json' (system ''): Cannot resolve canonical reference 'urn:ietf:bcp:13' to CodeSystem (at CapabilityStatement.format[2])"
@@ -5451,10 +5461,11 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 0,
+        "errorCount": 1,
         "warningCount": 2,
         "output": [
           "[WARNING] Cannot resolve reference Patient/123 (at CarePlan.subject[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at CarePlan.activity[0].reference[0])",
           "[WARNING] Evaluation of FhirPath for constraint 'tim-9' failed: Invocation of operator 'or' failed: Invocation of operator 'and' failed: Invocation of function 'not' failed: Invocation of operator 'in' failed: Cannot cast from 'collection of code' to 'any type' (at CarePlan.activity[1].detail[0].scheduledTiming[0].repeat[0])"
         ]
       }
@@ -5512,9 +5523,11 @@
           ]
         },
         "firely-sdk-wip": {
-          "errorCount": 0,
+          "errorCount": 1,
           "warningCount": 0,
-          "output": []
+          "output": [
+            "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.generalPractitioner[0])"
+          ]
         }
       },
       "java": {
@@ -5528,9 +5541,11 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 0,
+        "errorCount": 1,
         "warningCount": 0,
-        "output": []
+        "output": [
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.generalPractitioner[0])"
+        ]
       }
     },
     {
@@ -5557,9 +5572,10 @@
           ]
         },
         "firely-sdk-wip": {
-          "errorCount": 0,
+          "errorCount": 1,
           "warningCount": 1,
           "output": [
+            "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.generalPractitioner[0])",
             "[WARNING] Instance failed constraint min-digits-sor \"SOR Identifiers are at minimum 15 digits long\" (at Patient.generalPractitioner[0].identifier[0].value[0])"
           ]
         }
@@ -5575,9 +5591,11 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 0,
+        "errorCount": 1,
         "warningCount": 0,
-        "output": []
+        "output": [
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Patient.generalPractitioner[0])"
+        ]
       }
     },
     {
@@ -6465,8 +6483,10 @@
       },
       "firely-sdk-wip": {
         "errorCount": 0,
-        "warningCount": 0,
-        "output": []
+        "warningCount": 1,
+        "output": [
+          "[WARNING] Instance failed constraint que-0 \"Name should be usable as an identifier for the module by machine processing applications such as code generation\" (at Questionnaire)"
+        ]
       }
     },
     {
@@ -7176,9 +7196,11 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 0,
+        "errorCount": 1,
         "warningCount": 0,
-        "output": []
+        "output": [
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Observation.subject[0])"
+        ]
       }
     },
     {
@@ -7476,9 +7498,10 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 2,
+        "errorCount": 3,
         "warningCount": 4,
         "output": [
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Parameters.parameter[0].resource[0].identifier[0].assigner[0])",
           "[WARNING] Cannot resolve reference http://example.org/old-payer/fhir (at Parameters.parameter[1].resource[0].contained[0].endpoint[0])",
           "[WARNING] Cannot resolve reference Patient/1 (at Parameters.parameter[1].resource[0].beneficiary[0])",
           "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Parameters.parameter[1].resource[0].payor[0])",
@@ -7511,9 +7534,10 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 2,
+        "errorCount": 3,
         "warningCount": 4,
         "output": [
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Parameters.parameter[0].resource[0].identifier[0].assigner[0])",
           "[WARNING] Cannot resolve reference http://example.org/old-payer/fhir (at Parameters.parameter[1].resource[0].contained[0].endpoint[0])",
           "[WARNING] Cannot resolve reference Patient/1 (at Parameters.parameter[1].resource[0].beneficiary[0])",
           "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Parameters.parameter[1].resource[0].payor[0])",
@@ -8397,11 +8421,12 @@
         ]
       },
       "firely-sdk-wip": {
-        "errorCount": 1,
+        "errorCount": 2,
         "warningCount": 1,
         "output": [
           "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Bundle.entry[0].resource[0].contained[0].target[0])",
-          "[WARNING] Cannot resolve reference # (at Bundle.entry[0].resource[0].contained[0].target[0])"
+          "[WARNING] Cannot resolve reference # (at Bundle.entry[0].resource[0].contained[0].target[0])",
+          "[ERROR] Instance failed constraint ref-1 \"SHALL have a contained resource if a local reference is provided\" (at Bundle.entry[0].resource[0].contained[0].agent[0].who[0])"
         ]
       }
     },


### PR DESCRIPTION
Mostly the invariant ref-1 is failing.

See AB#577