### PR TITLE
Changes because memberOf has been implemented by the SDK now.

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -5301,10 +5301,8 @@
         },
         "firely-sdk-wip": {
           "errorCount": 0,
-          "warningCount": 1,
-          "output": [
-            "[WARNING] Evaluation of FhirPath for constraint 'bc-mm-1' failed: Invocation of function 'memberOf' failed: The 'memberOf' function cannot be executed because the FhirEvaluationContext does not include a TerminologyService. (Parameter 'ctx') (at Basic.code[0], element Basic(http://hl7.org/fhir/test/StructureDefinition/member-of-CC-defn).code)"
-          ]
+          "warningCount": 0,
+          "output": []
         }
       },
       "java": {
@@ -5342,10 +5340,10 @@
           ]
         },
         "firely-sdk-wip": {
-          "errorCount": 0,
-          "warningCount": 1,
+          "errorCount": 1,
+          "warningCount": 0,
           "output": [
-            "[WARNING] Evaluation of FhirPath for constraint 'bc-mm-1' failed: Invocation of function 'memberOf' failed: The 'memberOf' function cannot be executed because the FhirEvaluationContext does not include a TerminologyService. (Parameter 'ctx') (at Basic.code[0], element Basic(http://hl7.org/fhir/test/StructureDefinition/member-of-CC-defn).code)"
+            "[ERROR] Instance failed constraint bc-mm-1 \"must be in a value set\" (at Basic.code[0], element Basic(http://hl7.org/fhir/test/StructureDefinition/member-of-CC-defn).code)"
           ]
         }
       },
@@ -5470,7 +5468,7 @@
           "errorCount": 0,
           "warningCount": 1,
           "output": [
-            "[WARNING] Evaluation of FhirPath for constraint 'pat-cnt-2or3-char' failed: Invocation of operator 'or' failed: Invocation of function 'memberOf' failed: The 'memberOf' function cannot be executed because the FhirEvaluationContext does not include a TerminologyService. (Parameter 'ctx') (at Patient.address[0].country[0], element Patient(http://hl7.org/fhir/test/StructureDefinition/Patient-lang-inv-profile).address.country)"
+            "[WARNING] Evaluation of FhirPath for constraint 'pat-cnt-2or3-char' failed: Invocation of operator 'or' failed: Invocation of function 'memberOf' failed: Object reference not set to an instance of an object. (at Patient.address[0].country[0], element Patient(http://hl7.org/fhir/test/StructureDefinition/Patient-lang-inv-profile).address.country)"
           ]
         }
       },
@@ -5510,7 +5508,7 @@
           "errorCount": 0,
           "warningCount": 1,
           "output": [
-            "[WARNING] Evaluation of FhirPath for constraint 'pat-cnt-2or3-char' failed: Invocation of operator 'or' failed: Invocation of function 'memberOf' failed: The 'memberOf' function cannot be executed because the FhirEvaluationContext does not include a TerminologyService. (Parameter 'ctx') (at Patient.address[0].country[0], element Patient(http://hl7.org/fhir/test/StructureDefinition/Patient-lang-inv-profile).address.country)"
+            "[WARNING] Evaluation of FhirPath for constraint 'pat-cnt-2or3-char' failed: Invocation of operator 'or' failed: Invocation of function 'memberOf' failed: Object reference not set to an instance of an object. (at Patient.address[0].country[0], element Patient(http://hl7.org/fhir/test/StructureDefinition/Patient-lang-inv-profile).address.country)"
           ]
         }
       },


### PR DESCRIPTION
In the SDK we have implemented the FP `memberOf()`. Using this in the Validator.API it will change the outcome of the manifest. That's why this PR is here.

Two tests are still not right and I've created an issue for that: https://github.com/FirelyTeam/firely-net-sdk/issues/2588 