### PR TITLE
Update manifest for Validator 3.1.1 release

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -84,6 +84,37 @@
               "extension": [
                 {
                   "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line",
+                  "valueInteger": 7
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-col",
+                  "valueInteger": 22
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-source",
+                  "valueString": "BindingValidator"
+                }
+              ],
+              "severity": "warning",
+              "code": "informational",
+              "details": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/dotnet-api-operation-outcome",
+                    "code": "6006"
+                  }
+                ],
+                "text": "Code 'active' (display 'active') from system 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical' has incorrect display 'active', should be 'Active'"
+              },
+              "diagnostics": "ElementDefinition trace: AllergyIntolerance.clinicalStatus",
+              "expression": [
+                "AllergyIntolerance.clinicalStatus[0]"
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line",
                   "valueInteger": 26
                 },
                 {
@@ -3007,7 +3038,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'UNK': Operation validate code failed: valueset 'http://terminology.hl7.org/ValueSet/v3-NullFlavor|4.0.1' is unknown."
+                "text": "Terminology service failed while validating code 'UNK': Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: Encounter.reasonCode->CodeableConcept.extension->Extension(http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor).value",
               "expression": [
@@ -8486,7 +8517,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Operation validate code failed: valueset 'http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000' is unknown. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Pattern).category[ResultType]",
                 "expression": [
@@ -8815,7 +8846,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Operation validate code failed: valueset 'http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000' is unknown. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Value).category[ResultType]",
                 "expression": [
@@ -9201,7 +9232,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '104' (system 'http://myownsystem.info/sct'): Operation validate code failed: valueset 'http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000' is unknown. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '104' (system 'http://myownsystem.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Value).category[ResultType]",
                 "expression": [
@@ -9236,7 +9267,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Operation validate code failed: valueset 'http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000' is unknown. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Value).category[ResultType]",
                 "expression": [
@@ -12799,7 +12830,7 @@
             {
               "severity": "fatal",
               "code": "invalid",
-              "diagnostics": "Can only exit from a resource part."
+              "diagnostics": "The 'id' start tag on line 4 position 4 does not match the end tag of 'List'. Line 7, position 3."
             }
           ]
         }
@@ -14037,7 +14068,7 @@
             {
               "severity": "fatal",
               "code": "invalid",
-              "diagnostics": "Can only exit from a resource part."
+              "diagnostics": "Unexpected DTD declaration. Line 6, position 10."
             }
           ]
         }
@@ -24839,7 +24870,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) 'C' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Operation validate code failed: valueset '#relationships' is unknown."
+                  "text": "Terminology service failed while validating concept with coding(s) 'C' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Unable to resolve ValueSet."
                 },
                 "diagnostics": "ElementDefinition trace: Patient(http://hl7.org/fhir/StructureDefinition/patient-translated-codes).contact.relationship",
                 "expression": [
@@ -24874,7 +24905,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) 'N' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Operation validate code failed: valueset '#relationships' is unknown."
+                  "text": "Terminology service failed while validating concept with coding(s) 'N' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Unable to resolve ValueSet."
                 },
                 "diagnostics": "ElementDefinition trace: Patient(http://hl7.org/fhir/StructureDefinition/patient-translated-codes).contact.relationship",
                 "expression": [
@@ -26399,7 +26430,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Operation validate code failed: valueset '#v1' is unknown. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -26434,7 +26465,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's2' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Operation validate code failed: valueset '#v1' is unknown. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's2' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -26469,7 +26500,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Operation validate code failed: valueset '#v1' is unknown. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27829,7 +27860,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Operation validate code failed: valueset '#v1' is unknown. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27864,7 +27895,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Operation validate code failed: valueset '#v1' is unknown. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27899,7 +27930,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Operation validate code failed: valueset '#v1' is unknown. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27975,7 +28006,7 @@
             {
               "severity": "fatal",
               "code": "invalid",
-              "diagnostics": "Can only exit from a resource part."
+              "diagnostics": "'\u000B', hexadecimal value 0x0B, is an invalid character. Line 28, position 34."
             }
           ]
         }
@@ -38274,7 +38305,7 @@
             {
               "severity": "fatal",
               "code": "invalid",
-              "diagnostics": "Can only exit from a resource part."
+              "diagnostics": "'\u001D', hexadecimal value 0x1D, is an invalid character. Line 23, position 76."
             }
           ]
         }
@@ -39086,7 +39117,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'image/jpg': Operation validate code failed: valueset 'http://www.rfc-editor.org/bcp/bcp13.txt' is unknown."
+                "text": "Terminology service failed while validating code 'image/jpg': Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: Bundle.signature->Signature.contentType",
               "expression": [
@@ -43621,7 +43652,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Operation validate code failed: valueset '#vs' is unknown."
+                  "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Unable to resolve ValueSet."
                 },
                 "diagnostics": "ElementDefinition trace: ValueSet(http://hl7.org/fhir/test/ValueSet/tx-extensible-suppression).compose.include.concept.designation.use",
                 "expression": [
@@ -43691,7 +43722,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Operation validate code failed: valueset '#vs' is unknown."
+                "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: ValueSet(http://hl7.org/fhir/test/ValueSet/tx-extensible-suppression).compose.include.concept.designation.use",
               "expression": [
@@ -55887,7 +55918,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'image/jpg': Operation validate code failed: valueset 'http://www.rfc-editor.org/bcp/bcp13.txt' is unknown."
+                "text": "Terminology service failed while validating code 'image/jpg': Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: Bundle.signature->Signature.contentType",
               "expression": [
@@ -57213,7 +57244,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'application/pdf': Operation validate code failed: valueset 'http://www.rfc-editor.org/bcp/bcp13.txt' is unknown."
+                "text": "Terminology service failed while validating code 'application/pdf': Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: DocumentManifest.contained->DocumentReference.content.attachment->Attachment.contentType",
               "expression": [
@@ -62611,7 +62642,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'fhir': Operation validate code failed: valueset 'http://terminology.hl7.org/ValueSet/hl7-work-group' is unknown."
+                "text": "Terminology service failed while validating code 'fhir': Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: StructureDefinition.extension->Extension(http://hl7.org/fhir/StructureDefinition/structuredefinition-wg).value",
               "expression": [
@@ -72974,7 +73005,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating coding '/min' (system 'http://unitsofmeasure.org'): Operation validate code failed: valueset 'http://fhir.de/ValueSet/UcumVitalsCommonDE' is unknown. (for slice valueQuantity)"
+                "text": "Terminology service failed while validating coding '/min' (system 'http://unitsofmeasure.org'): Unable to resolve ValueSet. (for slice valueQuantity)"
               },
               "diagnostics": "ElementDefinition trace: Observation(https://www.medizininformatik-initiative.de/fhir/ext/modul-icu/StructureDefinition/atemfrequenz).value[valueQuantity]",
               "expression": [
@@ -73009,7 +73040,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code '/min': Operation validate code failed: valueset 'https://www.medizininformatik-initiative.de/fhir/ext/modul-icu/ValueSet/ValueSet-Unit-equivalent-UCUM-breaths_per-minute' is unknown. (for slice valueQuantity)"
+                "text": "Terminology service failed while validating code '/min': Unable to resolve ValueSet. (for slice valueQuantity)"
               },
               "diagnostics": "ElementDefinition trace: Observation(https://www.medizininformatik-initiative.de/fhir/ext/modul-icu/StructureDefinition/atemfrequenz).value[valueQuantity].code",
               "expression": [
@@ -78628,7 +78659,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'MSK': Operation validate code failed: valueset 'http://terminology.hl7.org/ValueSet/v3-NullFlavor|4.0.1' is unknown."
+                "text": "Terminology service failed while validating code 'MSK': Unable to resolve ValueSet."
               },
               "diagnostics": "ElementDefinition trace: Patient.active->boolean.extension->Extension(http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor).value",
               "expression": [
@@ -78725,7 +78756,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating code 'MSK': Operation validate code failed: valueset 'http://terminology.hl7.org/ValueSet/v3-NullFlavor|4.0.1' is unknown."
+                  "text": "Terminology service failed while validating code 'MSK': Unable to resolve ValueSet."
                 },
                 "diagnostics": "ElementDefinition trace: Patient(http://hl7.org/fhir/test/StructureDefinition/Patient-profile-value-alternative).active->boolean.extension->Extension(http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor).value",
                 "expression": [
@@ -79913,7 +79944,7 @@
             {
               "severity": "fatal",
               "code": "invalid",
-              "diagnostics": "Can only exit from a resource part."
+              "diagnostics": "'\u0013', hexadecimal value 0x13, is an invalid character. Line 4, position 37."
             }
           ]
         }


### PR DESCRIPTION
The missing canonicals will be restore with next SDK bump after https://github.com/FirelyTeam/firely-net-sdk/pull/3470 gets pulled