### PR TITLE
Update expected outcomes for SDK 6.2.0 error message format

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -3038,7 +3038,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'UNK': Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating code 'UNK': Unable to resolve ValueSet http://terminology.hl7.org/ValueSet/v3-NullFlavor|4.0.1."
               },
               "diagnostics": "ElementDefinition trace: Encounter.reasonCode->CodeableConcept.extension->Extension(http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor).value",
               "expression": [
@@ -8517,7 +8517,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Pattern).category[ResultType]",
                 "expression": [
@@ -8846,7 +8846,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Value).category[ResultType]",
                 "expression": [
@@ -9232,7 +9232,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '104' (system 'http://myownsystem.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '104' (system 'http://myownsystem.info/sct'): Unable to resolve ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Value).category[ResultType]",
                 "expression": [
@@ -9267,7 +9267,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet. (for slice ResultType)"
+                  "text": "Terminology service failed while validating concept with coding(s) '275711006' (system 'http://snomed.info/sct'): Unable to resolve ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20171231000000. (for slice ResultType)"
                 },
                 "diagnostics": "ElementDefinition trace: Observation(http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation-Value).category[ResultType]",
                 "expression": [
@@ -24870,7 +24870,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) 'C' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Unable to resolve ValueSet."
+                  "text": "Terminology service failed while validating concept with coding(s) 'C' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Unable to resolve ValueSet #relationships."
                 },
                 "diagnostics": "ElementDefinition trace: Patient(http://hl7.org/fhir/StructureDefinition/patient-translated-codes).contact.relationship",
                 "expression": [
@@ -24905,7 +24905,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating concept with coding(s) 'N' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Unable to resolve ValueSet."
+                  "text": "Terminology service failed while validating concept with coding(s) 'N' (system 'http://terminology.hl7.org/CodeSystem/v2-0131'): Unable to resolve ValueSet #relationships."
                 },
                 "diagnostics": "ElementDefinition trace: Patient(http://hl7.org/fhir/StructureDefinition/patient-translated-codes).contact.relationship",
                 "expression": [
@@ -26430,7 +26430,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet #v1. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -26465,7 +26465,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's2' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's2' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet #v1. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -26500,7 +26500,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet #v1. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27860,7 +27860,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet #v1. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27895,7 +27895,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's1' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet #v1. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -27930,7 +27930,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet. (for slice slice1)"
+                  "text": "Terminology service failed while validating coding 's3' (system 'http://tst.org/fhir/CodeSystem/test-meds'): Unable to resolve ValueSet #v1. (for slice slice1)"
                 },
                 "diagnostics": "ElementDefinition trace: Medication(http://test.org/fhir/StructureDefinition/meds-test).code.coding[slice1]",
                 "expression": [
@@ -39117,7 +39117,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'image/jpg': Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating code 'image/jpg': Unable to resolve ValueSet http://www.rfc-editor.org/bcp/bcp13.txt."
               },
               "diagnostics": "ElementDefinition trace: Bundle.signature->Signature.contentType",
               "expression": [
@@ -43652,7 +43652,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Unable to resolve ValueSet."
+                  "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Unable to resolve ValueSet #vs."
                 },
                 "diagnostics": "ElementDefinition trace: ValueSet(http://hl7.org/fhir/test/ValueSet/tx-extensible-suppression).compose.include.concept.designation.use",
                 "expression": [
@@ -43722,7 +43722,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating coding 'something' (system 'http://hl7.org/fhir/test/CodeSystem/something'): Unable to resolve ValueSet #vs."
               },
               "diagnostics": "ElementDefinition trace: ValueSet(http://hl7.org/fhir/test/ValueSet/tx-extensible-suppression).compose.include.concept.designation.use",
               "expression": [
@@ -55918,7 +55918,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'image/jpg': Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating code 'image/jpg': Unable to resolve ValueSet http://www.rfc-editor.org/bcp/bcp13.txt."
               },
               "diagnostics": "ElementDefinition trace: Bundle.signature->Signature.contentType",
               "expression": [
@@ -57244,7 +57244,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'application/pdf': Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating code 'application/pdf': Unable to resolve ValueSet http://www.rfc-editor.org/bcp/bcp13.txt."
               },
               "diagnostics": "ElementDefinition trace: DocumentManifest.contained->DocumentReference.content.attachment->Attachment.contentType",
               "expression": [
@@ -62642,7 +62642,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'fhir': Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating code 'fhir': Unable to resolve ValueSet http://terminology.hl7.org/ValueSet/hl7-work-group."
               },
               "diagnostics": "ElementDefinition trace: StructureDefinition.extension->Extension(http://hl7.org/fhir/StructureDefinition/structuredefinition-wg).value",
               "expression": [
@@ -73005,7 +73005,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating coding '/min' (system 'http://unitsofmeasure.org'): Unable to resolve ValueSet. (for slice valueQuantity)"
+                "text": "Terminology service failed while validating coding '/min' (system 'http://unitsofmeasure.org'): Unable to resolve ValueSet http://fhir.de/ValueSet/UcumVitalsCommonDE. (for slice valueQuantity)"
               },
               "diagnostics": "ElementDefinition trace: Observation(https://www.medizininformatik-initiative.de/fhir/ext/modul-icu/StructureDefinition/atemfrequenz).value[valueQuantity]",
               "expression": [
@@ -73040,7 +73040,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code '/min': Unable to resolve ValueSet. (for slice valueQuantity)"
+                "text": "Terminology service failed while validating code '/min': Unable to resolve ValueSet https://www.medizininformatik-initiative.de/fhir/ext/modul-icu/ValueSet/ValueSet-Unit-equivalent-UCUM-breaths_per-minute. (for slice valueQuantity)"
               },
               "diagnostics": "ElementDefinition trace: Observation(https://www.medizininformatik-initiative.de/fhir/ext/modul-icu/StructureDefinition/atemfrequenz).value[valueQuantity].code",
               "expression": [
@@ -78659,7 +78659,7 @@
                     "code": "6006"
                   }
                 ],
-                "text": "Terminology service failed while validating code 'MSK': Unable to resolve ValueSet."
+                "text": "Terminology service failed while validating code 'MSK': Unable to resolve ValueSet http://terminology.hl7.org/ValueSet/v3-NullFlavor|4.0.1."
               },
               "diagnostics": "ElementDefinition trace: Patient.active->boolean.extension->Extension(http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor).value",
               "expression": [
@@ -78756,7 +78756,7 @@
                       "code": "6006"
                     }
                   ],
-                  "text": "Terminology service failed while validating code 'MSK': Unable to resolve ValueSet."
+                  "text": "Terminology service failed while validating code 'MSK': Unable to resolve ValueSet http://terminology.hl7.org/ValueSet/v3-NullFlavor|4.0.1."
                 },
                 "diagnostics": "ElementDefinition trace: Patient(http://hl7.org/fhir/test/StructureDefinition/Patient-profile-value-alternative).active->boolean.extension->Extension(http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor).value",
                 "expression": [


### PR DESCRIPTION
## Summary
- SDK 6.2.0 enhanced the "Unable to resolve ValueSet" diagnostics to include the actual ValueSet URL.
- Regenerated 23 expected outcomes in `validator/manifest.json` via the validator's `AddFirelySdkValidatorResults` test against SDK 6.2.0.

## Test plan
- [ ] Manifest diff contains only the wording change (`Unable to resolve ValueSet.` -> `Unable to resolve ValueSet <url>.`); no unrelated changes.
- [ ] Downstream validator pipeline (firely-validator-api `release/3.2.0`) passes after bumping the submodule pointer.